### PR TITLE
Added slack notifications to integration test jobs

### DIFF
--- a/ldop_seed_job.groovy
+++ b/ldop_seed_job.groovy
@@ -99,6 +99,27 @@ export TF_VAR_branch_name="\${TOPIC}"
 """
     ) 
   }
+  publishers {
+    slackNotifier {
+      notifyFailure(true)
+      notifySuccess(true)
+      notifyAborted(false)
+      notifyNotBuilt(false)
+      notifyUnstable(false)
+      notifyBackToNormal(true)
+      notifyRepeatedFailure(false)
+      startNotification(true)
+      includeTestSummary(true)
+      includeCustomMessage(false)
+      customMessage(null)
+      buildServerUrl(null)
+      sendAs(null)
+      commitInfoChoice('AUTHORS_AND_TITLES')
+      teamDomain(null)
+      authToken(null)
+      room('ldop')
+    }
+  }
 }
 
 // Create LDOP Integration Testing Job
@@ -143,6 +164,25 @@ export TF_VAR_branch_name="\${TOPIC}"
           currentBuild()
         }
       }
+    }
+    slackNotifier {
+      notifyFailure(true)
+      notifySuccess(true)
+      notifyAborted(false)
+      notifyNotBuilt(false)
+      notifyUnstable(false)
+      notifyBackToNormal(true)
+      notifyRepeatedFailure(false)
+      startNotification(true)
+      includeTestSummary(true)
+      includeCustomMessage(false)
+      customMessage(null)
+      buildServerUrl(null)
+      sendAs(null)
+      commitInfoChoice('AUTHORS_AND_TITLES')
+      teamDomain(null)
+      authToken(null)
+      room('ldop')
     }
   }
 }


### PR DESCRIPTION
Added baseline slack integration per @RobertKelly's request. The ticket in the backlog will be a more in depth dive for slack integrations, namely non integration test builds and more. Also, this will change with Jenkinsfile pipelines. 