### PR TITLE
LDOP-169 re-adding the cleanup-images job

### DIFF
--- a/ldop_seed_job.groovy
+++ b/ldop_seed_job.groovy
@@ -111,3 +111,15 @@ echo \"Running integration tests\"
         }
     }
 }
+
+///////////////////////////
+// image cleanup job
+///////////////////////////
+job("${project}/cleanup-images") {
+  triggers {
+    cron('00 10 * * *')
+  }
+  steps {
+    shell('docker rmi -f $(docker images -aq) || echo "some images weren\'t deleted automatically"')
+  }
+}


### PR DESCRIPTION
re-adding the cleanup-images job that was unintentionally deleted by 82d56e1c47609f7ca98d6e0f213f15bcff9d467c

This job runs on a cron at 10am UTC (2am PST) and forcefully removes all cached images on build.liatrio.com